### PR TITLE
Clean up: creative work

### DIFF
--- a/schemas/creativeWork.schema.tpl.json
+++ b/schemas/creativeWork.schema.tpl.json
@@ -45,12 +45,6 @@
         "legalPerson"
       ]
     },
-    "digitalIdentifier": {
-      "_instruction": "Add the globally unique and persistent digital identifier of this creative work.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/DOI"
-      ]
-    },
     "editor": {
       "type": "array",
       "minItems": 1,

--- a/schemas/creativeWork.schema.tpl.json
+++ b/schemas/creativeWork.schema.tpl.json
@@ -2,62 +2,48 @@
   "properties": {
     "abstract": {
       "type": "string",
-      "_instruction": "Enter the abstract of the creative work."
+      "_instruction": "Enter the abstract or a short description of the creative work."
+    },    
+    "author": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all parties that contributed to this creative work as authors.",
+      "_linkedCategories": [
+        "legalPerson"
+      ]
+    },    
+    "citedPublication": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all references this creative work cites.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/DOI",
+        "https://openminds.ebrains.eu/core/ISBN"
+      ]
+    },    
+    "copyright": {
+      "_instruction": "Enter the copyright information of this creative work.",
+      "_embeddedTypes": [
+        "https://openminds.ebrains.eu/core/Copyright"
+      ]
+    },
+    "creationDate": {
+      "type": "string",
+      "_formats": [
+        "date"
+      ],
+      "_instruction": "Enter the date on which this creative work was created, formatted as '2023-02-07'."
     },
     "custodian": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Enter the person or people responsible for the creative work (e.g. the corresponding author).",
+      "_instruction": "Add all parties that fulfill the role of a custodian for this creative work (e.g., a corresponding author). Custodians are typically the main contact in case of misconduct, obtain permission from the contributors to publish personal information, and maintain the content and quality of the creative work.",
       "_linkedCategories": [
         "legalPerson"
       ]
-    },
-    "author": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add one or several authors (person or organization) that contributed to the production and publication of this creative work.",
-      "_linkedCategories": [
-        "legalPerson"
-      ]
-    },
-    "citedPublication": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add citations or references from this work to another creative work",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/DOI",
-        "https://openminds.ebrains.eu/core/ISBN"
-      ]
-    },
-    "copyright": {
-      "_instruction": "Add the copyright information of this creative work.",
-      "_embeddedTypes": [
-        "https://openminds.ebrains.eu/core/Copyright"
-      ]
-    },
-    "dateCreated": {
-      "type": "string",
-      "_formats": [
-        "date"
-      ],
-      "_instruction": "Enter the date on which the creative work was created."
-    },
-    "dateModified": {
-      "type": "string",
-      "_formats": [
-        "date"
-      ],
-      "_instruction": "Enter the date on which the creative work was last modified."
-    },
-    "datePublished": {
-      "type": "string",
-      "_formats": [
-        "date"
-      ],
-      "_instruction": "Enter the date when this version of the creative work was published or uploaded to a preprint server."
     },
     "digitalIdentifier": {
       "_instruction": "Add the globally unique and persistent digital identifier of this creative work.",
@@ -69,7 +55,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add one or more people who edited the creative work.",
+      "_instruction": "Add all persons that edited this creative work.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/Person"
       ]
@@ -78,42 +64,56 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all funding information of this creative work version.",
+      "_instruction": "Add all funding information of this creative work.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/Funding"
       ]
-    },
-    "name": {
-      "type": "string",
-      "_instruction": "Enter the full title of this creative work."
-    },
-    "keyword": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add controlled or suggest new terms as keywords to this creative work",
-      "_linkedCategories": [
-        "studyTarget"
-      ]
-    },
-    "license": {
-      "_instruction": "Add the license for this creative work.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/License"
-      ]
-    },
-    "publisher": {
-      "_instruction": "Enter the person or organisation who/which published this version of the creative work.",
-      "_linkedCategories": [
-        "legalPerson"
-      ]
-    },
+    },        
     "IRI": {
       "type": "string",
       "_formats": [
         "iri"
       ],
-      "_instruction": "Enter a URL/IRI at which this creative work is available."
+      "_instruction": "Enter the internationalized resource identifier (IRI) to this creative work."
+    },   
+    "keyword": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all relevant keywords to this creative work either by adding controlled terms or by suggesting new terms.",
+      "_linkedCategories": [
+        "keyword"
+      ]
+    },
+    "license": {
+      "_instruction": "Add the license of this creative work.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/License"
+      ]
+    },
+    "modificationDate": {
+      "type": "string",
+      "_formats": [
+        "date"
+      ],
+      "_instruction": "Enter the date on which this creative work was last modfied, formatted as '2023-02-07'."
+    },   
+    "name": {
+      "type": "string",
+      "_instruction": "Enter the name (or title) of this creative work."
+    },
+    "publicationDate": {
+      "type": "string",
+      "_formats": [
+        "date"
+      ],
+      "_instruction": "Enter the date on which this creative work was published, formatted as '2023-02-07'."
+    },
+    "publisher": {
+      "_instruction": "Add the party (private or commercial) that published this creative work.",
+      "_linkedCategories": [
+        "legalPerson"
+      ]
     },
     "versionIdentifier": {
       "type": "string",


### PR DESCRIPTION
MINOR changes:
- improved instructions
- establish alphabetical order
- all date property name changed to fit new convention to prefer a noun + Date/Time at the end and/or the shorter version if a noun doesn't make much sense or would need to be at the end (Note: 1:1 relationship between our property and the schema.org property can be established in the vocab files instead; we don't need to stick to schema.org, especially when they do not have a consistent naming convention either:
     - `dateCreated` replace by `creationDate`
     - `dateModified` replace by `modificationDate`
     - `datePublished` replace by `publicationDate`
 

MAJOR changes:
- removed `digitalIdentifier` from schema since it is redefined on every schema that extends this concept schema

SPECIAL ATTENTION:
- replace category `studyTarget` for property `keyword` with category `keyword`; @apdavison, this makes probably more sense since all controlledTerms receive this category, while study target is only added to a few selected ones? 