### PR TITLE
Clean up: learning resource

### DIFF
--- a/schemas/learningResource.schema.tpl.json
+++ b/schemas/learningResource.schema.tpl.json
@@ -1,50 +1,52 @@
 {
   "_type": "https://openminds.ebrains.eu/publications/LearningResource",
   "_extends": "creativeWork.schema.tpl.json",
-  "required": [
-    "name",
+  "required": [    
     "about",
-    "datePublished"
+    "name",
+    "publicationDate"
   ],
-  "properties": {
-    "competencyRequired": {
-        "type": "string",
-        "_instruction": "Enter the knowledge, skills, or abilities that are prerequisites for being able to use the learning resource."
-    },
-    "educationalLevel": {
-      "_instruction": "Add the level of the resource in terms of progression through an educational or training context.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/EducationalLevel"
-      ]
-    },
-    "learningResourceType": {
-      "_instruction": "Add the type of the learning resource",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/LearningResourceType"
-      ]
-    },
-    "teaches": {
-        "type": "string",
-        "_instruction": "Enter a description of the learning objectives."
-    },
-    "timeRequired": {
-        "_instruction": "Typical time it takes to work with or through this learning resource for the target audience.",
-        "_embeddedTypes": [
-            "https://openminds.ebrains.eu/core/QuantitativeValue",
-            "https://openminds.ebrains.eu/core/QuantitativeValueRange"
-        ]
-    },
+  "properties": {        
     "about": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add the research product(s) to which this learning resource applies.",
+      "_instruction": "Add all research product (versions) this learning resource are about. Note that the learning resource should supplement the usage of the research product (versions) with e.g., instructions on their usage or additional information.",
+      "_linkedCategories": [
+        "researchProduct"
+      ]
+    },
+    "digitalIdentifier": {
+      "_instruction": "Add the globally unique and persistent digital identifier of this creative work.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/DatasetVersion",
-        "https://openminds.ebrains.eu/core/ModelVersion",
-        "https://openminds.ebrains.eu/core/SoftwareVersion",
-        "https://openminds.ebrains.eu/core/WebServiceVersion",
-        "https://openminds.ebrains.eu/core/MetaDataModelVersion"
+        "https://openminds.ebrains.eu/core/DOI"
+      ]
+    },
+    "educationalLevel": {
+      "_instruction": "Add the educational level that best summarizes the prerequisite of this learning resource.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/EducationalLevel"
+      ]
+    },    
+    "learningOutcome": {
+        "type": "string",
+        "_instruction": "Enter a description for the expected learning outcomes of this learning resource."
+    },    
+    "prerequisite": {
+        "type": "string",
+        "_instruction": "Enter any knowledge, skills, or abilities that are required to be able to use this learning resource."
+    },
+    "requiredTime": {
+        "_instruction": "Enter the time that is required to complete this learning resource.",
+        "_embeddedTypes": [
+            "https://openminds.ebrains.eu/core/QuantitativeValue",
+            "https://openminds.ebrains.eu/core/QuantitativeValueRange"
+        ]
+    },    
+    "type": {
+      "_instruction": "Add the type of this learning resource.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/LearningResourceType"
       ]
     }
   }


### PR DESCRIPTION
MINOR changes:
- improved instructions 
- establish alphabetical order
- changed `datePublished` to `publicationDate` according to change on creative work schema
- added `digitalIdentifier` in accordance with removal from concept schema
- renamed `timeRequired` to `requiredTime` to adhere to our naming convention (noun + Date/Time at the end preferred; if noun is not possible, adverb can be used or whatever is shorter) 
- renamed `learningResourceType` to `type` to follow new convention to use `type` when the additional information is not adding any other meaning than imposed by schema already 

MAJOR changes:
none

SPECIAL ATTENTION:
- `about` links to category `researchProduct`; it seemed odd that a learning resource is only limited to be about a few of our research products, this change does not remove any of the ones that were linked but only extends this list with all the other research products, ok @apdavison?
- renamed `teaches` to `learningOutcome` which seems more suitable, fits our vocabulary better (we have basically never use a verb for any property name before) and is often used on e.g. course description pages (as far as I could see) 
- renamed `competencyRequired` to `prerequisite` which seems more suitable, fits our vocabulary better, is shorter and is often used on e.g. course description pages (as far as I could see) 
