### PR TITLE
Clean up: live paper section

### DIFF
--- a/schemas/livePaperSection.schema.tpl.json
+++ b/schemas/livePaperSection.schema.tpl.json
@@ -26,9 +26,6 @@
       "_instruction": "Enter an integer that is used to sort this live paper section in ascending order with other live paper sections of the overarching live paper version."
     },   
     "type": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
       "_instruction": "Add the type of this live paper section."
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/LivePaperSectionType"

--- a/schemas/livePaperSection.schema.tpl.json
+++ b/schemas/livePaperSection.schema.tpl.json
@@ -6,7 +6,7 @@
     "order",
     "type"
   ],
-  "properties": {       
+  "properties": {
     "description": {
       "type": "string",
       "_instruction": "Enter a description of this live paper section."

--- a/schemas/livePaperSection.schema.tpl.json
+++ b/schemas/livePaperSection.schema.tpl.json
@@ -26,10 +26,8 @@
       "_instruction": "Enter an integer that is used to sort this live paper section in ascending order with other live paper sections of the overarching live paper version."
     },   
     "type": {
-      "_instruction": "Add the type of this live paper section."
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/LivePaperSectionType"
-      ]
+      "type": "string",
+      "_instruction": "Add the type of this live paper section (e.g., 'custom', 'generic', 'models', 'morphology', or 'traces')."
     }
   }
 }

--- a/schemas/livePaperSection.schema.tpl.json
+++ b/schemas/livePaperSection.schema.tpl.json
@@ -1,33 +1,38 @@
 {
   "_type": "https://openminds.ebrains.eu/publications/LivePaperSection",
   "required": [
-    "isPartOf",
+    "isPartOf",    
+    "name",
     "order",
-    "sectionType",
-    "name"
+    "type"
   ],
-  "properties": {
-    "sectionType": {
+  "properties": {       
+    "description": {
       "type": "string",
-      "_instruction": "Add the type of this live paper section: one of 'custom', 'generic', 'models', 'morphology', 'traces'"
+      "_instruction": "Enter a description of this live paper section."
+    },
+    "isPartOf": {     
+      "_instruction": "Add the live paper version this live paper section is part of.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/publications/LivePaperVersion"
+      ]
+    }, 
+    "name": {
+      "type": "string",
+      "_instruction": "Enter the name (or title) of this live paper section."
     },
     "order": {
       "type": "integer",
-      "_instruction": "Enter the order in which this section should appear."
-    },
-    "name": {
-      "type": "string",
-      "_instruction": "Enter a title for this section."
-    },
-    "description": {
-      "type": "string",
-      "_instruction": "Enter a textual description of the section contents."
-    },
-    "isPartOf": {
+      "_instruction": "Enter an integer that is used to sort this live paper section in ascending order with other live paper sections of the overarching live paper version."
+    },   
+    "type": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add the type of this live paper section."
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/publications/LivePaperVersion"
-      ],
-      "_instruction": "Enter the live paper version this section is part of."
+        "https://openminds.ebrains.eu/controlledTerms/LivePaperSectionType"
+      ]
     }
   }
 }


### PR DESCRIPTION
MINOR changes:
- improved instructions 
- establish alphabetical order
- establish correct order within a property
- renamed `sectionType` to `type` to adhere to new convention to use type when the additional information is not adding any other meaning than imposed by schema already 

MAJOR changes:
- `type` links to controlledTerm (object) instead of string (Note: controlledTerms still need to be added, but terms will be the ones that were listed in the old instructions:
     -  custom
     - generic
     - model
     - morphology
     - trace)

SPECIAL ATTENTION:
none
