### PR TITLE
Clean up: live paper version

### DIFF
--- a/schemas/livePaperVersion.schema.tpl.json
+++ b/schemas/livePaperVersion.schema.tpl.json
@@ -1,13 +1,16 @@
 {
   "_type": "https://openminds.ebrains.eu/publications/LivePaperVersion",
   "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
-  "required": ["digitalIdentifier", "license"],
+  "required": [
+    "digitalIdentifier", 
+    "license"
+  ],
   "properties": {
     "about": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add links to the datasets, models or software contained within or described by this version of the live paper.",
+      "_instruction": "Add all datasets, models and/or software that are part of or described by this live paper version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DatasetVersion",
         "https://openminds.ebrains.eu/core/ModelVersion",
@@ -18,19 +21,16 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "If necessary, add one or several authors (person or organization) that contributed to the production and publication of this live paper version. Note that these authors will overwrite the ones provided in the live paper product this version belongs to.",
-      "_linkedCategories": ["legalPerson"]
-    },
-    "lastModified": {
-        "type": "string",
-        "_formats": [
-          "date-time"
-        ],
-        "_instruction": "Enter the date and time at which the live paper was last modified."
+      "_instruction": "Add all parties that contributed to this live paper version as authors. Note that these authors will overwrite the author list provided for the overarching live paper.",
+      "_linkedCategories": [
+        "legalPerson"
+      ]
     },
     "digitalIdentifier": {
-      "_instruction": "Add the globally unique and persistent digital identifier of this live paper version.",
-      "_linkedTypes": ["https://openminds.ebrains.eu/core/DOI"]
+      "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/DOI"
+      ]
     },
     "isAlternativeVersionOf": {
       "type": "array",
@@ -48,19 +48,17 @@
       ]
     },
     "license": {
-      "_instruction": "Add the license for this live paper version.",
-      "_linkedTypes": ["https://openminds.ebrains.eu/core/License"]
-    },
-    "relatedPublication": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add an identifier for the book, chapter, article, or preprint for which this live paper provides supplementary material.",
+      "_instruction": "Add the license of this live paper version.",
       "_linkedTypes": [
-          "https://openminds.ebrains.eu/core/DOI",
-          "https://openminds.ebrains.eu/core/ISBN",
-          "https://openminds.ebrains.eu/core/ISSN"
+        "https://openminds.ebrains.eu/core/License"
       ]
+    },
+    "modificationDate": {
+        "type": "string",
+        "_formats": [
+          "date-time"
+        ],
+        "_instruction": "Enter the date and time on which this live paper version was last modfied, formatted as '2023-02-07T16:00:00+00:00'."
     }
   }
 }

--- a/schemas/livePaperVersion.schema.tpl.json
+++ b/schemas/livePaperVersion.schema.tpl.json
@@ -10,7 +10,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all datasets, models and/or software that are part of or described by this live paper version.",
+      "_instruction": "Add all datasets, models and/or software that are part of or are described by this live paper version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DatasetVersion",
         "https://openminds.ebrains.eu/core/ModelVersion",
@@ -58,7 +58,7 @@
         "_formats": [
           "date-time"
         ],
-        "_instruction": "Enter the date and time on which this live paper version was last modfied, formatted as '2023-02-07T16:00:00+00:00'."
+        "_instruction": "Enter the date and time on which this live paper version was last modified, formatted as 'YYYY-MM-DDThh:mm:ssTZD' (e.g., '2023-02-07T16:00:00+00:00')."
     }
   }
 }


### PR DESCRIPTION
MINOR changes:
- improved instructions 
- establish alphabetical order
- renamed `lastModified` to `modificationDate` to adhere to new convention, reduce list of property names and because it fits the needs in this schema (instructions state that the date of the last modification should be entered)

MAJOR changes:
- removed `relatedPublication` and adjusted them in the concept schema to fit the needs for this schema; please see https://github.com/HumanBrainProject/openMINDS_core/pull/387:
     - added `ISSN` there
     - adjusted instructions to fit the original ones from here better 
     - NOTE: By doing this change, `livePaperSection` will gain `HANDLE` as allowed value, is this ok @apdavison? 

SPECIAL ATTENTION:
none
