### PR TITLE
revert unintended change

### DIFF
--- a/schemas/livePaperResourceItem.schema.tpl.json
+++ b/schemas/livePaperResourceItem.schema.tpl.json
@@ -8,9 +8,11 @@
   ],
   "properties": {   
     "hostedBy": {
-      "_instruction": "Add the host organization of this live paper resource item.",
+      "_instruction": "Add the web service or organization that hosts this live paper resource item.",
       "_linkedTypes": [
-        "core:Organization"
+        "core:Organization",
+        "core:WebService",
+        "controlledTerms:Service"
       ]
     },
     "IRI": {


### PR DESCRIPTION
For some reason, commit 104783cc7330ef4e4a9118b4de612c0eec46cc85, which was about changing the namespace, also reverted a recent property change (originally implemented in #19). This reverts the reversion!