### PR TITLE
Fix for #26

### DIFF
--- a/schemas/livePaperVersion.schema.tpl.json
+++ b/schemas/livePaperVersion.schema.tpl.json
@@ -59,15 +59,6 @@
           "date-time"
         ],
         "_instruction": "Enter the date and time on which this live paper version was last modified, formatted as 'YYYY-MM-DDThh:mm:ssTZD' (e.g., '2023-02-07T16:00:00+00:00')."
-    },
-    "relatedPublication": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all further publications besides the full documentation that provide the original context for the production of this research product version (e.g., an original research article that used or produced the data of this research product version).",
-      "_linkedCategories": [
-        "publicationReference"
-      ]
     }
   }
 }


### PR DESCRIPTION
remove relatedPublication property in LivePaperVersion, which is unnecessary because it is inherited from ResearchProductVersion in core