### PR TITLE
switch connection between RP and RPVs

### DIFF
--- a/schemas/livePaper.schema.tpl.json
+++ b/schemas/livePaper.schema.tpl.json
@@ -19,15 +19,6 @@
       "_linkedTypes": [
         "core:DOI"
       ]
-    },
-    "hasVersion": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all versions of this live paper.",
-      "_linkedTypes": [
-        "publications:LivePaperVersion"
-      ]
     }
   }
 }

--- a/schemas/livePaperVersion.schema.tpl.json
+++ b/schemas/livePaperVersion.schema.tpl.json
@@ -2,7 +2,7 @@
   "_type": "publications:LivePaperVersion",
   "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
   "required": [
-    "digitalIdentifier", 
+    "digitalIdentifier",
     "license"
   ],
   "properties": {
@@ -32,7 +32,13 @@
         "core:DOI"
       ]
     },
-    "isAlternativeVersionOf": {
+    "isPrecededBy": {
+      "_instruction": "Add the live paper version preceding this live paper version.",
+      "_linkedTypes": [
+        "publications:LivePaperVersion"
+      ]
+    },
+    "isVariantOf": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
@@ -41,10 +47,10 @@
         "publications:LivePaperVersion"
       ]
     },
-    "isNewVersionOf": {
-      "_instruction": "Add the live paper version preceding this live paper version.",
+    "isVersionOf": {
+      "_instruction": "Add the version-independent information about this live paper.",
       "_linkedTypes": [
-        "publications:LivePaperVersion"
+        "publications:LivePaper"
       ]
     },
     "license": {


### PR DESCRIPTION
RPVs now refer to their parent RP with isVersionOf. We remove hasVersion from the RP.

Related to openMetadataInitiative/openMINDS_core#553